### PR TITLE
fedora: enable gpgcheck for intel repo

### DIFF
--- a/fedora
+++ b/fedora
@@ -17,8 +17,10 @@ RUN if [ "${INTEL}" =  "yes" ]; then \
   rm parallel_studio_xe_*.tgz && \
   cd parallel_studio_xe_*/rpm && \
   printf "[icc]\nname=icc\nbaseurl=$PWD\nenabled=1" > /etc/yum.repos.d/icc.repo && \
+  rpm --import ../PUBLIC_KEY.PUB && \
   ( dnf -y update || dnf -y update ) && \
-  dnf --nogpgcheck -y install intel-parallel-studio-xe-icc intel-parallel-studio-xe-mkl && \
+  dnf -y install findutils && \
+  dnf -y install intel-parallel-studio-xe-icc intel-parallel-studio-xe-mkl && \
   dnf clean all; \
 fi
 


### PR DESCRIPTION
Easy to work with in down-steam containers if the gpg for the intel repo gets imported, see e.g.
https://github.com/ECP-copa/ci-containers/runs/2052678146?check_suite_focus=true