### PR TITLE
Revert "CI: try never fedora version"

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -21,7 +21,7 @@ jobs:
           - {dockerfile: 'ubuntu',   tag: 'rolling',          build_args: 'TAG=rolling'}
           - {dockerfile: 'ubuntu',   tag: 'devel',            build_args: 'TAG=devel', continue-on-error: 'true'}
           - {dockerfile: 'opensuse', tag: 'latest'}
-          - {dockerfile: 'fedora',   tag: 'intel',            build_args: 'INTEL=yes'}
+          - {dockerfile: 'fedora',   tag: 'intel',            build_args: 'TAG=35,INTEL=yes'}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout out code


### PR DESCRIPTION
This reverts commit f268c722840e3f35385f49be48e6fe0b66ffa7b1.

It appears that this commit broke the CI, see https://github.com/kokkos/kokkos/actions/runs/3160603672/jobs/5145245866, with
```
/usr/bin/ld: CMakeFiles/example.dir/foo.f.o: relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: failed to set dynamic section sizes: bad value
```
which we don't see in any other build.