### PR TITLE
Remove obsolete links in ubuntu image

### DIFF
--- a/ubuntu
+++ b/ubuntu
@@ -9,11 +9,6 @@ RUN apt-get update && \
     apt-get purge --autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-# create cc and c++ (CMake's default compiler) links for ccache
-RUN ln -s ../../bin/ccache /usr/lib/ccache/c++
-RUN ln -s ../../bin/ccache /usr/lib/ccache/cc
-
-
 RUN useradd -m -G sudo -u 1001 kokkos
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER kokkos


### PR DESCRIPTION
fixes https://github.com/kokkos/kokkos/issues/5723

Remove the links for `ccache` as we are now using [CMAKE_CXX_COMPILER_LAUNCHER variable](https://github.com/kokkos/kokkos/blob/b5bd709fd615a0a5bc78492f171307bdafa2f53a/.github/workflows/continuous-integration-workflow.yml#L108) to configure `CMake` explicitly.