### PR TITLE
Do not create `.ccache` directory

### DIFF
--- a/fedora
+++ b/fedora
@@ -23,4 +23,3 @@ ENV PATH=${INTEL:+/opt/intel/oneapi/compiler/latest/linux/bin:/opt/intel/oneapi/
 ENV LD_LIBRARY_PATH=${INTEL:+/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/mkl/latest/lib/intel64}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
 ENV CCACHE_MAXSIZE=250M
 WORKDIR /home/kokkos
-RUN mkdir .ccache

--- a/opensuse
+++ b/opensuse
@@ -12,4 +12,3 @@ USER kokkos
 ENV PATH=/usr/lib64/ccache${PATH:+:}${PATH}
 ENV CCACHE_MAXSIZE=250M
 WORKDIR /home/kokkos
-RUN mkdir .ccache

--- a/ubuntu
+++ b/ubuntu
@@ -15,4 +15,3 @@ USER kokkos
 ENV PATH=/usr/lib/ccache${PATH:+:}${PATH}
 ENV CCACHE_MAXSIZE=250M
 WORKDIR /home/kokkos
-RUN mkdir .ccache


### PR DESCRIPTION
Creating the `.ccache` directory is not necessary (also [`ccache` documentation](https://ccache.dev/manual/4.5.html#_configuration_options) considers it a "legacy" solution). Currently Kokkos CI ends up using `$HOME/.cache/ccache`.

fixes https://github.com/kokkos/kokkos/issues/5723