### PR TITLE
Push correct images to container registry

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -82,4 +82,5 @@ jobs:
         with:
           tags: ${{ env.docker-tag }}
           file: ${{ matrix.config.dockerfile }}
+          build-args: ${{ steps.build_args.outputs.args }}
           push: true

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to Github Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         if: github.repository_owner == 'kokkos' && ( github.event_name == 'push' ||  github.event_name == 'schedule' )
         with:
@@ -76,7 +76,7 @@ jobs:
                 -DKokkos_ENABLE_OPENMP=ON && \
               cmake --build builddir --parallel 2 && \
               ctest --test-dir builddir --output-on-failure"
-      - name: Push the image into Github Container Registry
+      - name: Push the image into GitHub Container Registry
         uses: docker/build-push-action@v4
         if: ${{ github.repository_owner == 'kokkos' && ( github.event_name == 'push' ||  github.event_name == 'schedule' ) }}
         with:


### PR DESCRIPTION
`Push the image into Github Container Registry` step was missing the `build-args` input argument. This resulted in wrong images (for example missing Intel compiler suite) being pushed into registry.