### PR TITLE
Update icpx build

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -26,7 +26,7 @@ jobs:
             - {dockerfile: 'ubuntu',   tag: 'latest-arm64', arm: 'true'}
             - {dockerfile: 'ubuntu',   tag: 'rolling',  build_args: 'TAG=rolling'}
             - {dockerfile: 'ubuntu',   tag: 'devel',    build_args: 'TAG=devel',    continue-on-error: 'true'}
-            - {dockerfile: 'ubuntu',   tag: 'intel',    build_args: 'TAG=22.04,INTEL=yes', cmake_args: '-DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_FLAGS=-fp-model=precise', continue-on-error: 'true'}
+            - {dockerfile: 'ubuntu',   tag: 'intel',    build_args: 'TAG=24.04,INTEL=yes', cmake_args: '-DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_FLAGS=-fp-model=precise', continue-on-error: 'true'}
             - {dockerfile: 'opensuse', tag: 'latest'}
     continue-on-error: ${{ matrix.config.continue-on-error == 'true' }}
     env:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -63,7 +63,9 @@ jobs:
         run: |
           docker run -t --rm -v ${{ github.workspace }}/kokkos:/kokkos -w /kokkos ${{ env.docker-tag }} \
             sh -c \
-              "cmake -B builddir \
+              "echo ${PATH} && \
+               find /opt/intel/oneapi -name "icpx" && \
+               cmake -B builddir \
                 ${{ matrix.config.cmake_args }} \
                 -DKokkos_ENABLE_HWLOC=ON \
                 -DKokkos_ENABLE_BENCHMARKS=ON \

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -18,16 +18,7 @@ jobs:
     strategy:
         matrix:
           config:
-            - {dockerfile: 'fedora',   tag: 'latest-amd64'}
-            - {dockerfile: 'fedora',   tag: 'latest-arm64', arm: 'true'}
-            - {dockerfile: 'fedora',   tag: 'rawhide-amd64',  build_args: 'TAG=rawhide',  continue-on-error: 'true'}
-            - {dockerfile: 'fedora',   tag: 'rawhide-arm64',  build_args: 'TAG=rawhide',  continue-on-error: 'true', arm: 'true'}
-            - {dockerfile: 'ubuntu',   tag: 'latest-amd64'}
-            - {dockerfile: 'ubuntu',   tag: 'latest-arm64', arm: 'true'}
-            - {dockerfile: 'ubuntu',   tag: 'rolling',  build_args: 'TAG=rolling'}
-            - {dockerfile: 'ubuntu',   tag: 'devel',    build_args: 'TAG=devel',    continue-on-error: 'true'}
             - {dockerfile: 'ubuntu',   tag: 'intel',    build_args: 'TAG=24.04,INTEL=yes', cmake_args: '-DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_FLAGS=-fp-model=precise', continue-on-error: 'true'}
-            - {dockerfile: 'opensuse', tag: 'latest'}
     continue-on-error: ${{ matrix.config.continue-on-error == 'true' }}
     env:
       docker-tag: ghcr.io/kokkos/ci-containers/${{ matrix.config.dockerfile }}:${{ matrix.config.tag }}

--- a/ubuntu
+++ b/ubuntu
@@ -7,23 +7,18 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
-       ccache clang clang-format clang-tidy cmake curl g++ gfortran git gnupg2 libgtest-dev libhwloc-dev libomp-dev llvm make ninja-build sudo vim wget zstd g++-12 && \
+       ccache clang clang-format clang-tidy cmake curl flang g++ gfortran git gnupg2 libgtest-dev libhwloc-dev libomp-dev llvm make ninja-build sudo vim wget zstd g++-12 && \
     if [ "$(uname -m)" = "x86_64" ]; then \
       apt-get install -y gcc-multilib g++-multilib gfortran-multilib; \
     fi && \
     apt-get purge --autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-# intel build happens on 22.04 LTS, which does not have flang, install flang unconditionally once intel gets bumped
 RUN if [ "${INTEL}" = "yes" ]; then \
   wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
   echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list && \
   apt-get update && \
-  apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mkl-devel && \
-  apt-get clean; \
-else \
-  apt-get update && \
-  apt-get install -y flang && \
+  apt-get install -y intel-ocloc intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl-devel && \
   apt-get purge --autoremove -y && \
   apt-get clean; \
 fi

--- a/ubuntu
+++ b/ubuntu
@@ -26,7 +26,7 @@ fi
 RUN useradd -m -G sudo -u 1001 kokkos
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER kokkos
-ENV ICPX_PATH=$(dirname "$(find /opt/intel/oneapi -name "icpx")")
+ENV ICPX_PATH=${INTEL:+$(dirname "$(find /opt/intel/oneapi -name "icpx")")}
 ENV PATH=${INTEL:+${ICPX_PATH}:${ICPX_PATH}/intel64}${PATH:+:}${PATH}
 ENV LD_LIBRARY_PATH=${INTEL:+${ICPX_PATH}/../compiler/lib/intel64:/opt/intel/oneapi/mkl/latest/lib/intel64}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
 ENV CCACHE_MAXSIZE=250M

--- a/ubuntu
+++ b/ubuntu
@@ -27,7 +27,6 @@ RUN useradd -m -G sudo -u 1001 kokkos
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN ls /opt/intel/oneapi/compiler/
 USER kokkos
-ENV ICPX_PATH=${INTEL:+$(dirname "$(find /opt/intel/oneapi -name "icpx")")}
 ENV PATH=${INTEL:+${ICPX_PATH}:${ICPX_PATH}/intel64}${PATH:+:}${PATH}
 ENV LD_LIBRARY_PATH=${INTEL:+${ICPX_PATH}/../compiler/lib/intel64:/opt/intel/oneapi/mkl/latest/lib/intel64}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
 ENV CCACHE_MAXSIZE=250M

--- a/ubuntu
+++ b/ubuntu
@@ -26,10 +26,8 @@ fi
 RUN useradd -m -G sudo -u 1001 kokkos
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER kokkos
-RUN if [ "${INTEL}" = "yes" ]; then \
-  find /opt/intel/oneapi -name "icpx"; \
-fi
-ENV PATH=${INTEL:+/opt/intel/oneapi/compiler/latest/linux/bin:/opt/intel/oneapi/compiler/latest/linux/bin/intel64}${PATH:+:}${PATH}
-ENV LD_LIBRARY_PATH=${INTEL:+/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/mkl/latest/lib/intel64}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
+ENV ICPX_PATH=$(dirname "$(find /opt/intel/oneapi -name "icpx")")
+ENV PATH=${INTEL:+${ICPX_PATH}:${ICPX_PATH}/intel64}${PATH:+:}${PATH}
+ENV LD_LIBRARY_PATH=${INTEL:+${ICPX_PATH}/../compiler/lib/intel64:/opt/intel/oneapi/mkl/latest/lib/intel64}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
 ENV CCACHE_MAXSIZE=250M
 WORKDIR /home/kokkos

--- a/ubuntu
+++ b/ubuntu
@@ -26,6 +26,9 @@ fi
 RUN useradd -m -G sudo -u 1001 kokkos
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER kokkos
+RUN if [ "${INTEL}" = "yes" ]; then \
+  find /opt/intel/oneapi -name "icpx"; \
+fi
 ENV PATH=${INTEL:+/opt/intel/oneapi/compiler/latest/linux/bin:/opt/intel/oneapi/compiler/latest/linux/bin/intel64}${PATH:+:}${PATH}
 ENV LD_LIBRARY_PATH=${INTEL:+/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/mkl/latest/lib/intel64}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
 ENV CCACHE_MAXSIZE=250M

--- a/ubuntu
+++ b/ubuntu
@@ -25,6 +25,7 @@ fi
 
 RUN useradd -m -G sudo -u 1001 kokkos
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN ls /opt/intel/oneapi/compiler/
 USER kokkos
 ENV ICPX_PATH=${INTEL:+$(dirname "$(find /opt/intel/oneapi -name "icpx")")}
 ENV PATH=${INTEL:+${ICPX_PATH}:${ICPX_PATH}/intel64}${PATH:+:}${PATH}


### PR DESCRIPTION
Recent oneAPI docker images are missing `ocloc` which makes using them for CI a pain. This pull request proposes to update the Intel build to ubuntu 24.04 and also install `ocloc`.